### PR TITLE
add all models from db

### DIFF
--- a/perl/lib/Bento/Meta.md
+++ b/perl/lib/Bento/Meta.md
@@ -23,6 +23,16 @@ This class is just a [Bento::Meta::Model](/perl/lib/Bento/Meta/Model.md) factory
     Load a model from MDF files, or from a Neo4j database. `$bolt_url` must
     use the `bolt://` scheme.
 
+- list\_db\_models($bolt\_url)
+
+    Lists all of the models found in a Neo4j database.  `$bolt_url` must
+    use the `bolt://` scheme.
+
+- load\_\_all\_db\_models($bolt\_url)
+
+    Loads all models found in a Neo4j database.  C<$bolt_url> must
+    use the C<bolt://> scheme. 
+
 - model($handle)
 
     The [Bento::Meta::Model](/perl/lib/Bento/Meta/Model.md) object corresponding to the handle.

--- a/perl/lib/Bento/Meta.pm
+++ b/perl/lib/Bento/Meta.pm
@@ -5,6 +5,7 @@ use Try::Tiny;
 use Log::Log4perl qw/:easy/;
 use strict;
 use warnings;
+no warnings qw/regexp/;
 
 our $VERSION = "0.2";
 

--- a/perl/t/010_meta__load_all_db_models.t
+++ b/perl/t/010_meta__load_all_db_models.t
@@ -1,0 +1,71 @@
+use Test::More tests => 9;
+use Test::Warn;
+use Test::Deep;
+use Test::Exception;
+use IPC::Run qw/run/;
+use Neo4j::Bolt;
+use lib '../lib';
+use Log::Log4perl qw/:easy/;
+use Bento::Meta;
+
+# --------------------
+# Desc:
+#   tests the Bento::Meta::load_all_db_models()
+#   broke out from 009_meta.t so that db loaded models would not conflict 
+#   with file loaded models (cannot load two models named ICDC)
+
+Log::Log4perl->easy_init($FATAL);
+my $ctr_name = "test$$";
+my $img = 'maj1/test-db-bento-meta';
+my $d = (-e 't' ? 't' : '.');
+
+####
+diag "Starting docker container '$ctr_name' with image $img";
+my @startcmd = split / /,
+  "docker run -d -P --name $ctr_name $img";
+my @portcmd = split / /, "docker container port $ctr_name";
+my @stopcmd = split / /,"docker kill $ctr_name";
+my @rmcmd = split / /, "docker rm $ctr_name";
+
+my ($in, $out, $err);
+unless (run(['docker'],'<pty<',\$in,'>pty>',\$out)) {
+  plan skip_all => "Docker not available for test database setup: skipping.";
+}
+run \@startcmd, \$in, \$out, \$err;
+if ($err) {
+  diag "docker error: $err";
+}
+else {
+  sleep 10;
+}
+$in=$err=$out='';
+run \@portcmd, \$in, \$out, \$err;
+my ($port) = grep /7687.tcp/, split /\n/,$out;
+($port) = $port =~ m/([0-9]+)$/;
+####
+
+ok my $cxn = Neo4j::Bolt->connect("bolt://localhost:$port"), 'create neo4j connection';
+SKIP : {
+  skip "Can't connect to test db: ".$cxn->errmsg, 1 unless $cxn->connected;
+  $meta = Bento::Meta->new, 'can create new Bento::Meta instance';
+
+  # test the models found in the database
+  ok my @actual_models = $meta->list_db_models("bolt://localhost:$port"), "list models from db";
+  is_deeply [sort @actual_models], [qw/CTDC ICDC/], "correct handles";
+  is scalar $meta->models, 0, "no models were loaded";
+
+  # test that load_all_db_models can load 2 models: ICDC and CTDC
+  ok my $model_count = $meta->load_all_db_models("bolt://localhost:$port"), "loads all models from db";
+  is scalar $meta->models, 2, "meta now has expected number of models";
+  isa_ok($meta->model('ICDC'), 'Bento::Meta::Model');
+  isa_ok($meta->model('CTDC'), 'Bento::Meta::Model');
+  ok !$meta->model('boog'), 'make sure uncreated model doesnt exist';
+}
+done_testing;
+
+END {
+  diag "Stopping container $ctr_name";
+  run \@stopcmd;
+  diag "Removing container $ctr_name";
+  run \@rmcmd;
+}


### PR DESCRIPTION
The main issue with Bento::Meta currently is that there isn’t a clean way to get all models from the MDB _a priori_. You have to know what models you want to pull out.

- updates $VERSION to '0.2'
- This PR adds two functions to Bento::Meta
    - ` list_db_models($bolt_url)` - lists all models (handles) in the database
    - `load_all_db_handles($bolt_url)` - loads all handles (from ` list_db_models($bolt_url)`
- updates documentation for Bento::Meta
- adds `010_meta__load_all_db_models.t` (testing above functions)
- avoids regexp warnings about unescaped left bracket in Cypher::Abstract::Peeler

Example code:
```perl
#!/usr/bin/env perl
use strict;
use warnings;
use Data::Dumper;
use Bento::Meta;
my $bolt_url = 'bolt://localhost:7687';
print "using version: $Bento::Meta::VERSION\n";
my $m = Bento::Meta->new;
my @handles = $m->list_db_models($bolt_url);
print Dumper(@handles);
```
or
```perl
my $m = Bento::Meta->new;
my @handles =  $m->load_all_db_models($bolt_url);
print Dumper (@handles);
```

attn: @majensen -- thoughts?
