### PR TITLE
Bugfix/bento mdb#6/fix prop duplication

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bento-meta"
-version = "0.2.3"
+version = "0.2.4"
 description = "Python drivers for Bento Metamodel Database"
 authors = [
   { name="Mark A. Jensen", email = "mark.jensen@nih.gov"},
@@ -20,7 +20,7 @@ classifiers = [
 
 [tool.poetry]
 name = "bento-meta"
-version = "0.2.3"
+version = "0.2.4"
 description = "Python drivers for Bento Metamodel Database"
 authors = [
     "Mark A. Jensen <mark.jensen@nih.gov>",

--- a/python/scripts/make_mapping_changelog.py
+++ b/python/scripts/make_mapping_changelog.py
@@ -1,11 +1,12 @@
 """converts mapping MDF to changelog"""
-import configparser
+
 from ast import literal_eval
 from pathlib import Path
-from typing import Dict, Generator, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import click
 import yaml
+from bento_meta.util.changelog import changeset_id_generator, update_config_changeset_id
 from bento_meta.util.cypher.clauses import (
     Case,
     Create,
@@ -19,37 +20,6 @@ from bento_meta.util.cypher.clauses import (
 )
 from bento_meta.util.cypher.entities import G, N, R, T, _anon, _plain_var
 from liquichange.changelog import Changelog, Changeset, CypherChange
-
-
-def get_initial_changeset_id(config_file_path: str) -> int:
-    """Gets initial changeset id from changelog config file"""
-    config = configparser.ConfigParser()
-    config.read(config_file_path)
-    try:
-        return config.getint(section="changelog", option="changeset_id")
-    except (configparser.NoSectionError, configparser.NoOptionError) as error:
-        print(error)
-        raise
-
-
-def changeset_id_generator(config_file_path: str) -> Generator[int, None, None]:
-    """
-    Iterator for changeset_id. Gets latest changeset id from changelog.ini
-    and provides up-to-date changeset id as
-    """
-    i = get_initial_changeset_id(config_file_path)
-    while True:
-        yield i
-        i += 1
-
-
-def update_config_changeset_id(config_file_path: str, new_changeset_id: int) -> None:
-    """Updates changelog config file with new changeset id"""
-    config = configparser.ConfigParser()
-    config.read(config_file_path)
-    config.set(section="changelog", option="changeset_id", value=str(new_changeset_id))
-    with open(file=config_file_path, mode="w", encoding="UTF-8") as config_file:
-        config.write(fp=config_file)
 
 
 def load_yaml(

--- a/python/scripts/make_model_changelog.py
+++ b/python/scripts/make_model_changelog.py
@@ -183,6 +183,7 @@ def process_model_nodes(model: Model, cypher_stmts) -> None:
 def process_model_edges(model: Model, cypher_stmts) -> None:
     """Generates cypher statements to create/merge an model's edges."""
     for edge in model.edges.values():
+        edge.nanoid = make_nanoid()
         generate_cypher_to_add_entity(edge, cypher_stmts)
         generate_cypher_to_add_relationship(edge, "has_src", edge.src, cypher_stmts)
         generate_cypher_to_add_relationship(edge, "has_dst", edge.dst, cypher_stmts)

--- a/python/scripts/make_model_changelog.py
+++ b/python/scripts/make_model_changelog.py
@@ -2,10 +2,9 @@
 Script takes one MDF file representing a model and produces a Liquibase 
 Changelog with the necessary changes to add the model to an MDB
 """
-import configparser
 import logging
 from pathlib import Path
-from typing import Dict, Generator, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import click
 from bento_mdf.mdf import MDF
@@ -13,39 +12,12 @@ from bento_meta.entity import Entity
 from bento_meta.mdb.mdb import make_nanoid
 from bento_meta.model import Model
 from bento_meta.objects import Concept, Term, ValueSet
+from bento_meta.util.changelog import changeset_id_generator, update_config_changeset_id
 from bento_meta.util.cypher.clauses import Create, Match, Merge, OnCreateSet, Statement
 from bento_meta.util.cypher.entities import N, R, T, _plain_var
 from liquichange.changelog import Changelog, Changeset, CypherChange
 
 logger = logging.getLogger(__name__)
-
-
-def get_initial_changeset_id(config_file_path: str) -> int:
-    """Gets initial changeset id from changelog config file"""
-    config = configparser.ConfigParser()
-    config.read(config_file_path)
-    try:
-        return config.getint(section="changelog", option="changeset_id")
-    except (configparser.NoSectionError, configparser.NoOptionError) as error:
-        logger.error(f"Reading changeset ID failed: {error}")
-        raise
-
-
-def changeset_id_generator(config_file_path: str) -> Generator[int, None, None]:
-    """Generates sequential changeset IDs by reading the latest ID from a config file."""
-    i = get_initial_changeset_id(config_file_path)
-    while True:
-        yield i
-        i += 1
-
-
-def update_config_changeset_id(config_file_path: str, new_changeset_id: int) -> None:
-    """Updates changelog config file with new changeset id."""
-    config = configparser.ConfigParser()
-    config.read(config_file_path)
-    config.set(section="changelog", option="changeset_id", value=str(new_changeset_id))
-    with open(file=config_file_path, mode="w", encoding="UTF-8") as config_file:
-        config.write(fp=config_file)
 
 
 def escape_quotes_in_attr(entity: Entity) -> None:

--- a/python/scripts/make_model_changelog.py
+++ b/python/scripts/make_model_changelog.py
@@ -191,6 +191,7 @@ def process_props(entity: Entity, cypher_stmts) -> None:
     if not entity.props:
         return
     for prop in entity.props.values():
+        prop.nanoid = make_nanoid()
         generate_cypher_to_add_entity(prop, cypher_stmts)
         generate_cypher_to_add_relationship(entity, "has_property", prop, cypher_stmts)
         process_tags(prop, cypher_stmts)

--- a/python/src/bento_meta/objects.py
+++ b/python/src/bento_meta/objects.py
@@ -77,6 +77,7 @@ class Property(Entity):
         "is_required": "simple",
         "concept": "object",
         "value_set": "object",
+        "parent_handle": "simple",
     }
     mapspec_ = {
         "label": "property",

--- a/python/src/bento_meta/objects.py
+++ b/python/src/bento_meta/objects.py
@@ -91,6 +91,7 @@ class Property(Entity):
             "units": "units",
             "item_domain": "item_domain",
             "is_required": "is_required",
+            "parent_handle": "parent_handle",
         },
         "relationship": {
             "concept": {"rel": ":has_concept>", "end_cls": "Concept"},

--- a/python/src/bento_meta/util/__init__.py
+++ b/python/src/bento_meta/util/__init__.py
@@ -3,6 +3,7 @@ bento_meta.util - Utilities
 
 bento_meta.util.cypher - Represent Cypher queries programmatically
 bento_meta.util.makeq - Create Cypher queries from API endpoint paths
+bento_meta.util.changelog - Utilities for working with Liquibase Changelogs
 """
 
-from . import cypher
+from . import changelog, cypher

--- a/python/src/bento_meta/util/changelog.py
+++ b/python/src/bento_meta/util/changelog.py
@@ -1,0 +1,38 @@
+"""
+bento_meta.util.changelog
+
+Common functions shared by changelog generation scripts
+"""
+import configparser
+import logging
+from typing import Generator, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def get_initial_changeset_id(config_file_path: str) -> int:
+    """Gets initial changeset id from changelog config file"""
+    config = configparser.ConfigParser()
+    config.read(config_file_path)
+    try:
+        return config.getint(section="changelog", option="changeset_id")
+    except (configparser.NoSectionError, configparser.NoOptionError) as error:
+        logger.error(f"Reading changeset ID failed: {error}")
+        raise
+
+
+def changeset_id_generator(config_file_path: str) -> Generator[int, None, None]:
+    """Generates sequential changeset IDs by reading the latest ID from a config file."""
+    i = get_initial_changeset_id(config_file_path)
+    while True:
+        yield i
+        i += 1
+
+
+def update_config_changeset_id(config_file_path: str, new_changeset_id: int) -> None:
+    """Updates changelog config file with new changeset id."""
+    config = configparser.ConfigParser()
+    config.read(config_file_path)
+    config.set(section="changelog", option="changeset_id", value=str(new_changeset_id))
+    with open(file=config_file_path, mode="w", encoding="UTF-8") as config_file:
+        config.write(fp=config_file)

--- a/python/tests/samples/test_changelog.ini
+++ b/python/tests/samples/test_changelog.ini
@@ -1,3 +1,3 @@
 [changelog]
-changeset_id = 6855
+changeset_id = 1
 

--- a/python/tests/test_014changelog.py
+++ b/python/tests/test_014changelog.py
@@ -5,6 +5,7 @@ import sys
 from bento_mdf.diff import diff_models
 from bento_mdf.mdf import MDF
 from bento_meta.objects import Property
+from bento_meta.util.changelog import update_config_changeset_id
 from scripts.make_diff_changelog import convert_diff_to_changelog
 from scripts.make_mapping_changelog import convert_mappings_to_changelog
 from scripts.make_model_changelog import (
@@ -33,6 +34,7 @@ def test_make_model_changelog():
     changelog = convert_model_to_changelog(
         model=mdf.model, author=AUTHOR, config_file_path=TEST_CHANGELOG_CONFIG
     )
+    update_config_changeset_id(TEST_CHANGELOG_CONFIG, 1)
     assert len(changelog.subelements) == 46
 
 
@@ -47,6 +49,7 @@ def test_make_diff_changelog():
         author=AUTHOR,
         config_file_path=TEST_CHANGELOG_CONFIG,
     )
+    update_config_changeset_id(TEST_CHANGELOG_CONFIG, 1)
     assert len(changelog.subelements) == 33
 
 
@@ -58,6 +61,7 @@ def test_make_mapping_changelog():
         config_file_path=TEST_CHANGELOG_CONFIG,
         _commit=_COMMIT,
     )
+    update_config_changeset_id(TEST_CHANGELOG_CONFIG, 1)
     assert len(changelog.subelements) == 6
 
 
@@ -69,6 +73,3 @@ def test_escape_quotes_in_attr():
 
     assert prop.handle == r"""Quote\'s Handle"""
     assert prop.desc == r"""quote\'s quote\'s \"quotes\""""
-
-
-test_make_model_changelog()


### PR DESCRIPTION
# Description
- Update package version from 0.2.3 to 0.2.4
- Edit make_model_changelog.py so that it generates nanoids for Edge & Property entities to prevent duplicate relationships between them and connected entities
- Move functions shared by multiple changelog scripts to util/changelog.py from the individual scripts
- Reset changeset id for changelog tests

Fixes bento-mdb#6