### PR TITLE
Pin neo4j driver version to 5.28.x [DATATEAM-269]

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bento-meta"
-version = "0.2.18"
+version = "0.2.19"
 description = "Python drivers for Bento Metamodel Database"
 authors = [
   { name="Mark A. Jensen", email = "mark.jensen@nih.gov"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,7 +35,7 @@ include = ["logs/log.ini"]
 python = "^3.10"
 PyYAML = ">=6.0.1"
 delfick-project = "^0.7.9"
-neo4j = ">=4.0"
+neo4j = "^5.28.0"
 nanoid = "^2.0.0"
 requests = "^2.32.4"
 tqdm = "^4.64.1"


### PR DESCRIPTION
We need to call session.read_transaction() in mdb.py. In neo4j 6.0.x, this method is renamed execute_read() and so the latest package will break bento-meta.