### PR TITLE
fix(*): update model and entity term keys

### DIFF
--- a/python/src/bento_meta/objects.py
+++ b/python/src/bento_meta/objects.py
@@ -89,7 +89,7 @@ class Node(Entity):
         super().__init__(init=init)
 
     @property
-    def annotations(self) -> list[Term] | None:
+    def annotations(self) -> dict | None:
         """Return `Term`s if the `Node` is annotated by `Term`s via a `Concept`."""
         if self.concept:
             return self.concept.terms
@@ -176,7 +176,7 @@ class Property(Entity):
         self.value_types = []
 
     @property
-    def annotations(self) -> list[Term] | None:
+    def annotations(self) -> dict | None:
         """If the `Property` is annotated by `Term`s via a `Concept`, return the `Term`s."""
         if self.concept:
             return self.concept.terms
@@ -248,7 +248,7 @@ class Edge(Entity):
         super().__init__(init=init)
 
     @property
-    def annotations(self) -> list[Term] | None:
+    def annotations(self) -> dict | None:
         """Return `Term`s if the `Edge` is annotated by `Term`s via a `Concept`."""
         if self.concept:
             return self.concept.terms

--- a/python/tests/test_002objects.py
+++ b/python/tests/test_002objects.py
@@ -42,12 +42,12 @@ def test_init_and_link_objects():
     concept = Concept()
     term.concept = concept
     other_concept = Concept()
-    concept.terms["sample"] = term
+    concept.terms[("sample", None, None, None)] = term
     sample.concept = concept
     [o] = [x for x in term.belongs.values()]
     assert o == concept
-    assert of_sample.src.concept.terms["sample"].value == "sample"
-    assert of_sample.src.annotations["sample"].value == "sample"
+    assert of_sample.src.concept.terms[("sample", None, None, None)].value == "sample"
+    assert of_sample.src.annotations[("sample", None, None, None)].value == "sample"
     pred = Predicate({"subject": concept, "object": other_concept, "handle": "isa"})
     assert type(pred.subject) == Concept
     assert type(pred.object) == Concept
@@ -69,7 +69,7 @@ def test_tags_on_objects():
     term = Term({"value": "sample"})
     concept = Concept()
     term.concept = concept
-    concept.terms["sample"] = term
+    concept.terms[("sample", None, None, None)] = term
     sample.concept = concept
     sample.props["this"] = Property({"that": "this"})
 

--- a/python/tests/test_003model.py
+++ b/python/tests/test_003model.py
@@ -24,8 +24,8 @@ def test_create_model():
     assert isinstance(model.nodes["case"], Node)
     assert model.props[("case", "days_to_enrollment")]
     model.annotate(case, Term({"value": "case", "origin_name": "CTOS"}))
-    assert model.nodes["case"].concept.terms[("case", "CTOS")]
-    assert model.nodes["case"].annotations[("case", "CTOS")]
+    assert model.nodes["case"].concept.terms[("case", "CTOS", None, None)]
+    assert model.nodes["case"].annotations[("case", "CTOS", None, None)]
     model.add_node({"handle": "sample"})
     assert model.nodes["sample"]
     assert isinstance(model.nodes["sample"], Node)
@@ -44,8 +44,8 @@ def test_create_model():
         model.props[("case", "case_id")],
         Term({"value": "case_id", "origin_name": "CTOS"}),
     )
-    assert case_id.concept.terms[("case_id", "CTOS")]
-    assert case_id.annotations[("case_id", "CTOS")]
+    assert case_id.concept.terms[("case_id", "CTOS", None, None)]
+    assert case_id.annotations[("case_id", "CTOS", None, None)]
     model.add_edge(of_case)
     assert model.edges[("of_case", "sample", "case")]
     assert model.contains(of_case.props["operator"])
@@ -55,8 +55,12 @@ def test_create_model():
         model.props[("of_case", "sample", "case", "operator")].value_domain == "boolean"
     )
     model.annotate(of_case, Term({"value": "of_case", "origin_name": "CTOS"}))
-    assert model.edges[("of_case", "sample", "case")].concept.terms[("of_case", "CTOS")]
-    assert model.edges[("of_case", "sample", "case")].annotations[("of_case", "CTOS")]
+    assert model.edges[("of_case", "sample", "case")].concept.terms[
+        ("of_case", "CTOS", None, None)
+    ]
+    assert model.edges[("of_case", "sample", "case")].annotations[
+        ("of_case", "CTOS", None, None)
+    ]
     dx = Property({"handle": "diagnosis", "value_domain": "value_set"})
     tm = Term({"value": "CRS", "origin_name": "Marilyn"})
     model.add_prop(case, dx)
@@ -67,6 +71,6 @@ def test_create_model():
         "fungusamongus",
     }
     assert len(model.terms) > 0
-    assert ("CRS", "Marilyn") in model.terms
-    assert ("case", "CTOS") in model.terms
+    assert ("CRS", "Marilyn", None, None) in model.terms
+    assert ("case", "CTOS", None, None) in model.terms
     assert dx.value_set in tm.belongs.values()


### PR DESCRIPTION
Fix term collision bug by changing term storage keys from 2-tuple to 4-tuple

BREAKING CHANGE: Model.terms and Concept.terms now use 4-tuple keys

Motivation:
Terms with identical handle/value and origin_name but different origin_id values were colliding, causing overwrite of one of the terms.

Changes:
- Model.terms: keys changed from (handle, origin_name) to (handle, origin_name, origin_id, origin_version)
- Concept.terms: updated to use same 4-tuple key structure
- Model.annotate(): creates 4-tuple keys when adding terms
- Model.add_terms(): creates 4-tuple keys for Model.terms
- Fixed annotations property type hint (list[Term] → dict)
- Updated tests to use new key structure

Previous Behavior:
model.terms[(handle, origin)] → stored/retrieved terms by 2-tuple key

New Behavior:
model.terms[(handle, origin_name, origin_id, origin_version)] → 4-tuple key (origin_id and origin_version can be None)